### PR TITLE
Overhaul aerodynamics

### DIFF
--- a/ED_FM_Template/FlightModel.cpp
+++ b/ED_FM_Template/FlightModel.cpp
@@ -164,6 +164,29 @@ void FlightModel::calculateAero()
 	double caoa2 = caoa * caoa;
 	double saoa2 = saoa * saoa;
 
+	double Cnb_stab = Cnb(m_state.m_mach);
+	double Cnp_stab = 0;	// TODO: add data from NASA CR-2144
+	double Cnr_stab = Cnr(m_state.m_mach);
+	double Cnda_stab = 0; 	// TODO: add data from NASA CR-2144
+	double Cndr_stab = Cndr(m_state.m_mach);
+	double Clb_stab = Clb(m_state.m_mach);
+	double Clp_stab = Clp(m_state.m_mach);
+	double Clr_stab = Clr(m_state.m_mach);
+	double Clda_stab = Clda(m_state.m_mach);
+	double Cldr_stab = Cldr(m_state.m_mach);
+
+	// Convert moments from stability to body frame (Ref. NASA CR-2144 Appendix B)
+	double Cnb_body = Cnb_stab * caoa + Clb_stab * saoa;
+	double Cnp_body = Cnp_stab * caoa2 - (Cnr_stab - Clp_stab) * saoa * caoa - Clr_stab * saoa2;
+	double Cnr_body = Cnr_stab * caoa2 + (Clr_stab + Cnp_stab) * saoa * caoa + Clp_stab * saoa2;
+	double Cnda_body = Cnda_stab * caoa + Clda_stab * saoa;
+	double Cndr_body = Cndr_stab * caoa + Cldr_stab * saoa;
+	double Clb_body = Clb_stab * caoa - Cnb_stab * saoa;
+	double Clp_body = Clp_stab * caoa2 - (Clr_stab + Cnp_stab) * saoa * caoa + Cnr_stab * saoa2;
+	double Clr_body = Clr_stab * caoa2 - (Cnr_stab - Clp_stab) * saoa * caoa - Cnp_stab * saoa2;
+	double Clda_body = Clda_stab * caoa - Cnda_stab * saoa;
+	double Cldr_body = Cldr_stab * caoa - Cndr_stab * saoa;
+
 	//set roll moment -- 
 	//Neu eingefügt am 14.02.2021 PJ-- "-" vor Clr eingefügt, da Clr Daten positiv waren und negativ sein müssten da Dämpfung
 	//m_moment.x-- "2 *" vor Clda eingefügt für stärkere Ailerons = schon besser-- "2*" vor Clp eingefügt -- "0,5 *" vor Clb eingefügt

--- a/ED_FM_Template/FlightModel.cpp
+++ b/ED_FM_Template/FlightModel.cpp
@@ -220,7 +220,7 @@ void FlightModel::calculateAero()
 
 	//set side force
 	//m_force.z
-	m_force.z += m_k * ((Cydr(m_state.m_mach) * m_input.getYaw()) + (Cyb(m_state.m_mach) * m_state.m_beta)); //neu eingefügt 28Mar21
+	m_force.z += m_k * ((Cydr(m_state.m_mach) * m_input.getYaw() * CON_RdDefGDR) + (Cyb(m_state.m_mach) * m_state.m_beta)); //neu eingefügt 28Mar21
 
 	// Convert forces from stability to body frame
 	m_force.x += -drag * cos(m_state.m_aoa) + lift * sin(m_state.m_aoa);

--- a/ED_FM_Template/FlightModel.cpp
+++ b/ED_FM_Template/FlightModel.cpp
@@ -159,6 +159,9 @@ void FlightModel::airborneInit()
 
 void FlightModel::calculateAero()
 {
+	double da = m_input.getRoll() * CON_aitgu;		// Aileron control surface deflection (sum of both right and left aileron deflections) (positive for positive rolling moment) - [rad]
+	double ds = -m_input.getPitch() * CON_hstdUP;	// Stabilizer surface deflection from trim (positive for TED, trailing edge down) - [rad]
+	double dr = -m_input.getYaw() * CON_RdDefGDR;	// Rudder deflection [positive for nose-left yawing moment (negative N)] - [rad]
 	double caoa = cos(m_state.m_aoa);
 	double saoa = sin(m_state.m_aoa);
 	double caoa2 = caoa * caoa;

--- a/ED_FM_Template/FlightModel.cpp
+++ b/ED_FM_Template/FlightModel.cpp
@@ -208,7 +208,7 @@ void FlightModel::calculateAero()
 	//approx m_force.y
 	// erster Versuch : m_force.y = m_k * (CLmach(m_state.m_mach) + CLa(m_state.m_aoa)); //Lift ist so schon gut ;-)
 	
-	m_force.y += m_k * (((CLa(m_state.m_mach) * m_state.m_aoa) + ((CLFlaps + CLblc) * m_flapDamage)) * ((m_lWingDamageCL + m_rWingDamageCL) / 2.0 ) ); //+ CLds(m_state.m_mach)); //aktuell nur Lift due to AoA ohne Stab-Lift 
+	double lift = m_k * (((CLa(m_state.m_mach) * m_state.m_aoa) + ((CLFlaps + CLblc) * m_flapDamage)) * ((m_lWingDamageCL + m_rWingDamageCL) / 2.0)); //+ CLds(m_state.m_mach)); //aktuell nur Lift due to AoA ohne Stab-Lift 
 
 	//set drag
 	//--eingefügt 16.02. es fehlt noch supersonic drag, gear-drag, flap-drag, brake-drag
@@ -216,11 +216,15 @@ void FlightModel::calculateAero()
 	//erster Versuch: m_force.x = -(m_k * (CDmach(m_state.m_mach) + CDa(m_state.m_aoa)
 		//+ ((CLmach(m_state.m_mach) + CLa(m_state.m_mach)) * (CLmach(m_state.m_mach) + CLa(m_state.m_mach))) / CON_pi * CON_AR * CON_e));
 	// statt 0.85 jetzt 0.80 * CDa(etc) um Alpha-Drag anzupassen.
-	m_force.x += -m_k * ((CDmin(m_state.m_mach)) + (0.80 * (CDa(m_state.m_mach) * m_state.m_aoa)) + (CDeng(m_state.m_mach)) + CDGear + CDFlaps + CDBrk + CDBrkCht); // +CDwave + CDi); CDwave und CDi wieder dazu, wenn DRAG geklärt.
+	double drag = m_k * ((CDmin(m_state.m_mach)) + (0.80 * (CDa(m_state.m_mach) * m_state.m_aoa)) + (CDeng(m_state.m_mach)) + CDGear + CDFlaps + CDBrk + CDBrkCht); // +CDwave + CDi); CDwave und CDi wieder dazu, wenn DRAG geklärt.
 
 	//set side force
 	//m_force.z
 	m_force.z += m_k * ((Cydr(m_state.m_mach) * m_input.getYaw()) + (Cyb(m_state.m_mach) * m_state.m_beta)); //neu eingefügt 28Mar21
+
+	// Convert forces from stability to body frame
+	m_force.x += -drag * cos(m_state.m_aoa) + lift * sin(m_state.m_aoa);
+	m_force.y += lift * cos(m_state.m_aoa) + drag * sin(m_state.m_aoa);
 }
 
 void FlightModel::thrustForce()

--- a/ED_FM_Template/FlightModel.cpp
+++ b/ED_FM_Template/FlightModel.cpp
@@ -159,6 +159,11 @@ void FlightModel::airborneInit()
 
 void FlightModel::calculateAero()
 {
+	double caoa = cos(m_state.m_aoa);
+	double saoa = sin(m_state.m_aoa);
+	double caoa2 = caoa * caoa;
+	double saoa2 = saoa * saoa;
+
 	//set roll moment -- 
 	//Neu eingefügt am 14.02.2021 PJ-- "-" vor Clr eingefügt, da Clr Daten positiv waren und negativ sein müssten da Dämpfung
 	//m_moment.x-- "2 *" vor Clda eingefügt für stärkere Ailerons = schon besser-- "2*" vor Clp eingefügt -- "0,5 *" vor Clb eingefügt
@@ -223,8 +228,8 @@ void FlightModel::calculateAero()
 	m_force.z += m_k * ((Cydr(m_state.m_mach) * -m_input.getYaw() * CON_RdDefGDR) + (Cyb(m_state.m_mach) * m_state.m_beta)); //neu eingefügt 28Mar21
 
 	// Convert forces from stability to body frame
-	m_force.x += -drag * cos(m_state.m_aoa) + lift * sin(m_state.m_aoa);
-	m_force.y += lift * cos(m_state.m_aoa) + drag * sin(m_state.m_aoa);
+	m_force.x += -drag * caoa + lift * saoa;
+	m_force.y += lift * caoa + drag * saoa;
 }
 
 void FlightModel::thrustForce()

--- a/ED_FM_Template/FlightModel.cpp
+++ b/ED_FM_Template/FlightModel.cpp
@@ -170,7 +170,7 @@ void FlightModel::calculateAero()
 	*/
 
 	//-------------------------NEUE Versíon MIT Beschränkung des Max-Ausschalgs--------------------------------------------------------
-	m_moment.x += m_q * (Clb(m_state.m_mach) * m_state.m_beta + Clda(m_state.m_mach) * (((m_input.getRoll() * CON_aitgu) + m_input.getTrimmAilR() - m_input.getTrimmAilL()) * m_ailDamage) + (m_lWingDamageCD + m_rWingDamageCD) + (0.55 * Cldr(m_state.m_mach)) * (m_input.getYaw() * CON_RdDefGDR))
+	m_moment.x += m_q * (Clb(m_state.m_mach) * m_state.m_beta + Clda(m_state.m_mach) * (((m_input.getRoll() * CON_aitgu) + m_input.getTrimmAilR() - m_input.getTrimmAilL()) * m_ailDamage) + (m_lWingDamageCD + m_rWingDamageCD) + (0.55 * Cldr(m_state.m_mach)) * (-m_input.getYaw() * CON_RdDefGDR))
 		+ 0.25 * m_state.m_airDensity * m_scalarVelocity * CON_A * CON_b * CON_b * (2.0 * Clp(m_state.m_mach) * m_state.m_omega.x + (1.5 * -Clr(m_state.m_mach)) * m_state.m_omega.y);
 
 	//set pitch moment-- 
@@ -220,7 +220,7 @@ void FlightModel::calculateAero()
 
 	//set side force
 	//m_force.z
-	m_force.z += m_k * ((Cydr(m_state.m_mach) * m_input.getYaw() * CON_RdDefGDR) + (Cyb(m_state.m_mach) * m_state.m_beta)); //neu eingefügt 28Mar21
+	m_force.z += m_k * ((Cydr(m_state.m_mach) * -m_input.getYaw() * CON_RdDefGDR) + (Cyb(m_state.m_mach) * m_state.m_beta)); //neu eingefügt 28Mar21
 
 	// Convert forces from stability to body frame
 	m_force.x += -drag * cos(m_state.m_aoa) + lift * sin(m_state.m_aoa);

--- a/ED_FM_Template/FlightModel.h
+++ b/ED_FM_Template/FlightModel.h
@@ -37,13 +37,7 @@ public:
 	void update(double dt);
 
 
-	void L_stab();
-	void M_stab();
-	void N_stab();
-
-	void lift();
-	void drag();
-	void sideForce();
+	void calculateAero();
 	void thrustForce();
 
 	//----------Cockpit-Shaker--------------------------


### PR DESCRIPTION
This PR contains these modifications:
- force and moments calculations were grouped into a single function to allow use of local variables and avoid repeated evaluations
- lift and drag forces are now converted from stability to body frame before being added
- made a few corrections to the rudder behavior (rudder angle factor was missing in sideforce, and the sign was inverted in the roll and sideforce)
- added conversions for the moment coefficients from stability to body frame, though I haven't implemented it yet as some data was missing

TODO:
- [ ] add unused coefficients (CLds, CDM, CLM, CMM)
- [ ] add missing coefficients (Cnp, Cnda)